### PR TITLE
Avoid call to window in window-less environment

### DIFF
--- a/src/Pager.js
+++ b/src/Pager.js
@@ -59,7 +59,11 @@ class Pager extends Events {
       view => view.origin
     )
 
-    window.addEventListener('resize', this.resize)
+    if (typeof window === 'undefined') {
+      return
+    } else {
+      window.addEventListener('resize', this.resize)  
+    }
   }
 
   destroy() {


### PR DESCRIPTION
Because Pager's constructor function calls `window`, it results in an error during server-side rendering, where `window` is unavailable. This small PR fixes it.