### PR TITLE
Add a minimal test for server-side rendering of the ViewPager component

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev": "webpack-dev-server --devtool eval --hot --progress --colors --host 0.0.0.0",
     "postbuild": "NODE_ENV=production TARGET=minify webpack --config webpack.prod.config.js",
     "prebuild": "rm -rf dist && mkdir dist",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "test": "mocha tests/.setup.js --reporter spec tests/**/*.js"
   },
   "repository": {
     "type": "git",
@@ -58,11 +59,14 @@
     "babel-preset-stage-0": "^6.16.0",
     "chokidar": "^1.6.1",
     "css-loader": "^0.25.0",
+    "enzyme": "^2.6.0",
     "http-server": "^0.9.0",
+    "mocha": "^3.2.0",
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
     "react": "15.3.2",
+    "react-addons-test-utils": "15.3.2",
     "react-collapse": "^2.3.3",
     "react-dom": "15.3.2",
     "react-height": "^2.1.1",

--- a/tests/.setup.js
+++ b/tests/.setup.js
@@ -1,0 +1,1 @@
+require('babel-register')();

--- a/tests/ViewPager.spec.js
+++ b/tests/ViewPager.spec.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import reactDom from 'react-dom/server'
+import { shallow } from 'enzyme';
+import assert from 'assert'
+
+import { ViewPager, Frame, Track, View }  from '../src/react-view-pager'
+
+describe('ViewPager', () => {
+
+  let pages = [1, 2, 3].map(page => <div>{page}</div>)
+
+  it('can render on the server side', () => {
+    let shallowRenderedComponent = shallow(
+      <ViewPager>
+        <Frame>
+          <Track>
+            {pages.map((page, index) => <View key={index}>{page}</View>)}
+          </Track>
+        </Frame>
+      </ViewPager>
+    )
+    assert(shallowRenderedComponent.length, 1);
+  })
+
+})


### PR DESCRIPTION
Here is a very minimal test that will currently fail with the following message:

```
var hasNativeCollections = typeof window.WeakMap === 'function' && typeof window.Map === 'function';
                                  ^
ReferenceError: window is not defined
```

To see it pass (just for the fun of it), comment out all references to `resize-observer-polyfill` ([here](https://github.com/souporserious/react-view-pager/blob/c6fc1cff991271352126c75e10bfff88465f82ab/src/Pager.js#L2), [here](https://github.com/souporserious/react-view-pager/blob/c6fc1cff991271352126c75e10bfff88465f82ab/src/Pager.js#L112), and [here](https://github.com/souporserious/react-view-pager/blob/c6fc1cff991271352126c75e10bfff88465f82ab/src/Pager.js#L186)), and run `npm test`.

It would be great to incorporate a test like this in the release of the package, just to make sure that ViewPager can still render fine in the windowless environment.


P.S.: Sorry; I added pakages the old way, using npm, not yarn; so yarn.lock has not been updated.