### PR TITLE
Translate3d with fractional pixels leads to blurry images

### DIFF
--- a/src/Pager.js
+++ b/src/Pager.js
@@ -13,7 +13,7 @@ class Track extends PagerElement {
     const { x, y } = this.pager.getPositionValue(trackPosition)
     const trackSize = this.pager.getTrackSize()
     const style = {
-      [TRANSFORM]: `translate3d(${x}px, ${y}px, 0)`
+      [TRANSFORM]: `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`
     }
 
     if (trackSize) {


### PR DESCRIPTION
Hi !

We've been using react-view-pager for a while, so first, thanks for this project and for open sourcing it!

I've noticed recently that, in our use case, for odd resolutions, the `trackPosition` could end up being a fractional number.
This, linked to the usage of `translate3d` produces blurry images on Chrome (I didn't test other browsers).

With this in mind, there are 2 possible solutions:
- Switch to `translate` instead of `translate3d` and loose the performance advantage that `translate3d` offers. The `z` being fixed to 0 it will be a non breaking change.
- Round the positions to nearest int to ensure sharp images, this may not work for everyone but it combine performances with sharpness.

In this PR I've chosen the second solution as both performance & sharpness are important to us; but the `translate` solution could also be "good enough".

Below are two examples, if you look at the bread crust you can see the difference in sharpness.
![blurry](https://user-images.githubusercontent.com/1537324/45894902-0d5f5980-bdd0-11e8-8ea4-e93e1d4c99dc.png)
![sharp](https://user-images.githubusercontent.com/1537324/45894911-151efe00-bdd0-11e8-9413-a121bd9efeb4.png)


